### PR TITLE
feat: 5번 룰 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ app
 - 2: cafeteriaShouldSupportDiscount
 - 3: userShouldExist
 - 4: barcodeShouldBeActive
-- 5: discountShouldBeFirstToday
+- 5: discountAtThisCafeteriaShouldBeFirstToday
 - 6: barcodeShouldNotBeUsedRecently
 - 7: tokenShouldBeValid
 

--- a/actions/db/initial-db-contents.mjs
+++ b/actions/db/initial-db-contents.mjs
@@ -148,7 +148,7 @@ export default {
     },
     {
       id: 5,
-      name: 'discountShouldBeFirstToday',
+      name: 'discountAtThisCafeteriaShouldBeFirstToday',
       description: '같은 날짜에 할인받은 기록이 없어야 합니다.',
       enabled: true,
     },

--- a/lib/domain/services/TransactionService.mjs
+++ b/lib/domain/services/TransactionService.mjs
@@ -96,7 +96,7 @@ class TransactionService {
 
   async _testBasicThingsForCancel(transaction) {
     return this._testBasicThings(transaction, 'Cancel', [
-      5, /* ignore rule 5: discountShouldBeFirstToday (should rather exist) */
+      5, /* ignore rule 5: discountAtThisCafeteriaShouldBeFirstToday (should rather exist) */
       6, /* ignore rule 6: barcodeShouldNotBeUsedRecently */
     ]);
   }
@@ -127,7 +127,7 @@ class TransactionService {
         failure: () => DiscountValidationResults.USUAL_FAIL,
       }, {
         ruleId: 5,
-        validate: () => this.transactionValidator.discountShouldBeFirstToday(userId),
+        validate: () => this.transactionValidator.discountAtThisCafeteriaShouldBeFirstToday(userId, cafeteriaId),
         failure: () => DiscountValidationResults.USUAL_FAIL,
       }, {
         ruleId: 6,

--- a/lib/domain/services/rule-number-table.md
+++ b/lib/domain/services/rule-number-table.md
@@ -4,6 +4,6 @@
 - 2: cafeteriaShouldSupportDiscount
 - 3: userShouldExist
 - 4: barcodeShouldBeActive
-- 5: discountShouldBeFirstToday
+- 5: discountAtThisCafeteriaShouldBeFirstToday
 - 6: barcodeShouldNotBeUsedRecently
 - 7: tokenShouldBeValid

--- a/lib/domain/validators/DiscountTransactionValidator.mjs
+++ b/lib/domain/validators/DiscountTransactionValidator.mjs
@@ -51,7 +51,7 @@ class DiscountTransactionValidator {
 
   // RULE NUMBER 5
   // Rule of user
-  discountShouldBeFirstToday(userId) {
+  discountAtThisCafeteriaShouldBeFirstToday(userId, cafeteriaId) {
     throw new Error('Not implemented!');
   }
 

--- a/lib/interfaces/validators/DiscountTransactionValidatorImpl.mjs
+++ b/lib/interfaces/validators/DiscountTransactionValidatorImpl.mjs
@@ -172,15 +172,21 @@ class DiscountTransactionValidatorImpl extends DiscountTransactionValidator {
     return !!recentlyActivated; /* should be recently activated */
   }
 
-  async discountShouldBeFirstToday(userId) {
+  async discountAtThisCafeteriaShouldBeFirstToday(userId, cafeteriaId) {
     if (!userId) {
       return false;
     }
 
-    const transactionsToday = await this.transactionRepository
-      .getAllTransactionsOfUserToday(userId);
+    if (!cafeteriaId) {
+      return false;
+    }
 
-    return transactionsToday.length === 0;
+    const transactionsToday = await this.transactionRepository.getAllTransactionsOfUserToday(userId);
+
+    const transactionsTodayAtThisCafeteria = transactionsToday
+      .filter((transaction) => transaction.cafeteriaId === cafeteriaId);
+
+    return transactionsTodayAtThisCafeteria.length === 0;
   }
 
   async barcodeShouldNotBeUsedRecently(userId, intervalSec) {

--- a/test/mocks/DiscountTransactionValidatorMock.mjs
+++ b/test/mocks/DiscountTransactionValidatorMock.mjs
@@ -40,7 +40,7 @@ class DiscountTransactionValidatorMock extends DiscountTransactionValidator {
     throw new Error('Not mocked! You need extra mock here');
   }
 
-  discountShouldBeFirstToday(userId) {
+  discountAtThisCafeteriaShouldBeFirstToday(userId, cafeteriaId) {
     throw new Error('Not mocked! You need extra mock here');
   }
 

--- a/test/unit/domain/services/TransactionService.test.mjs
+++ b/test/unit/domain/services/TransactionService.test.mjs
@@ -18,7 +18,6 @@
  */
 
 import resolve, {initWithOverrides} from '../../../../lib/common/di/resolve';
-
 import TransactionService from '../../../../lib/domain/services/TransactionService';
 import DiscountValidationResults from '../../../../lib/domain/constants/DiscountValidationResults';
 import DiscountTransaction from '../../../../lib/domain/entities/DiscountTransaction';
@@ -50,9 +49,11 @@ describe('# validateDiscountTransaction', () => {
     expect(result).toBe(expectation);
   };
 
-  it('should throw on null param', async () => {
+  it('should throw on undefined param', async () => {
     const service = resolve(TransactionService);
 
+    // Sending null to the argument destructor will cause an exception.
+    // noinspection JSCheckFunctionSignatures
     await expect(service.validateDiscountTransaction(null)).rejects.toThrow();
   });
 
@@ -76,7 +77,7 @@ describe('# validateDiscountTransaction', () => {
     await validationTest('cafeteriaShouldSupportDiscount', DiscountValidationResults.UNUSUAL_WRONG_PARAM);
     await validationTest('userShouldExist', DiscountValidationResults.UNUSUAL_NO_BARCODE);
     await validationTest('barcodeShouldBeActive', DiscountValidationResults.USUAL_FAIL);
-    await validationTest('discountShouldBeFirstToday', DiscountValidationResults.USUAL_FAIL);
+    await validationTest('discountAtThisCafeteriaShouldBeFirstToday', DiscountValidationResults.USUAL_FAIL);
     await validationTest('barcodeShouldNotBeUsedRecently', DiscountValidationResults.USUAL_FAIL);
     await validationTest('tokenShouldBeValid', DiscountValidationResults.UNUSUAL_WRONG_PARAM);
   });
@@ -86,7 +87,7 @@ describe('# validateDiscountTransaction', () => {
     await validationTest('cafeteriaShouldSupportDiscount', DiscountValidationResults.USUAL_SUCCESS, 2);
     await validationTest('userShouldExist', DiscountValidationResults.USUAL_SUCCESS, 3);
     await validationTest('barcodeShouldBeActive', DiscountValidationResults.USUAL_SUCCESS, 4);
-    await validationTest('discountShouldBeFirstToday', DiscountValidationResults.USUAL_SUCCESS, 5);
+    await validationTest('discountAtThisCafeteriaShouldBeFirstToday', DiscountValidationResults.USUAL_SUCCESS, 5);
     await validationTest('barcodeShouldNotBeUsedRecently', DiscountValidationResults.USUAL_SUCCESS, 6);
     await validationTest('tokenShouldBeValid', DiscountValidationResults.USUAL_SUCCESS, 7);
   });
@@ -114,7 +115,7 @@ describe('# commitDiscountTransaction', () => {
     await commitTest('cafeteriaShouldSupportDiscount', true, DiscountCommitResults.FAIL);
     await commitTest('userShouldExist', true, DiscountCommitResults.FAIL);
     await commitTest('barcodeShouldBeActive', true, DiscountCommitResults.FAIL);
-    await commitTest('discountShouldBeFirstToday', true, DiscountCommitResults.FAIL);
+    await commitTest('discountAtThisCafeteriaShouldBeFirstToday', true, DiscountCommitResults.FAIL);
     // await commitTest('barcodeShouldNotBeUsedRecently', true, DiscountCommitResults.FAIL);
     /** Do not check barcode time when committing! */
   });
@@ -158,7 +159,7 @@ const getMockedService = function(failAt, bypass=0) {
     'cafeteriaShouldSupportDiscount',
     'userShouldExist',
     'barcodeShouldBeActive',
-    'discountShouldBeFirstToday',
+    'discountAtThisCafeteriaShouldBeFirstToday',
     'barcodeShouldNotBeUsedRecently',
 
     // token validation

--- a/test/unit/interfaces/validators/DiscountTransactionValidatorImpl.test.mjs
+++ b/test/unit/interfaces/validators/DiscountTransactionValidatorImpl.test.mjs
@@ -293,8 +293,8 @@ describe('# isBarcodeActive', () => {
 });
 
 describe('# isFirstToday', () => {
-  const firstTest = async function(userId, expectation) {
-    const actual = await resolve(DiscountTransactionValidator).discountShouldBeFirstToday(userId);
+  const firstTest = async function(userId, cafeteriaId, expectation) {
+    const actual = await resolve(DiscountTransactionValidator).discountAtThisCafeteriaShouldBeFirstToday(userId, cafeteriaId);
 
     expect(actual).toBe(expectation);
   };
@@ -319,20 +319,26 @@ describe('# isFirstToday', () => {
     return mock;
   };
 
-  it('should catch null userId in param', async () => {
-    await firstTest(null, false);
+  it('should catch null userId and cafeteriaId in param', async () => {
+    await firstTest(null, null, false);
   });
 
   it('should catch crazy userId in param', async () => {
     setTransactionMock(201701562, 2, 1);
 
-    await firstTest(8934892389289, true); // this is a right behavior
+    await firstTest(8934892389289, 1, true); // this is a right behavior
   });
 
-  it('should say this user already made a transaction today', async () => {
+  it('should say this user already made a transaction today at cafeteria with id 1', async () => {
     setTransactionMock(201701562, 2, 1);
 
-    await firstTest(201701562, false);
+    await firstTest(201701562, 1, false);
+  });
+
+  it('should say this user already made a transaction today but not at cafeteria with id 3', async () => {
+    setTransactionMock(201701562, 2, 1);
+
+    await firstTest(201701562, 3, true);
   });
 });
 


### PR DESCRIPTION
5번 룰 이름을 기존 discountShouldBeFirstToday에서 discountAtThisCafeteriaShouldBeFirstToday로 수정.
Validator에서 룰에 해당하는 메소드에 식당 골라내는 로직 추가(repository는 변경없음).
동반되는 테스트와 룰 문서, mock 데이터 및 실서버 DB의 cafeteria_discount_rules 테이블의 5번 룰 이름과 설명 수정.